### PR TITLE
Add file with version, update readme, fix middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,20 @@ This can be used to track a request throughout your architecture by ensuring tha
 
 ## Installation
 
+Add this line to your application's Gemfile:
+
 ```ruby
-# Gemfile
-gem install 'rack-request-id-passthrough'
+gem 'rack-request-id-passthrough', require: 'rack/request-id-passthrough'
+```
+
+And then execute:
+```bash
+bundle install
+```
+
+Or install it yourself as:
+```bash
+gem install rack-request-id-passthrough
 ```
 
 #### Sinatra (or any rack based stack)
@@ -29,19 +40,25 @@ module MyApp
   class Application < Rails::Application
     # ...
     # warning! Make sure that you insert this middleware early so that you can capture all relevant network calls
-    config.middleware.insert_after Rack::Runtime, Rack::RequestIDPassthrough, {opts}
+    config.middleware.insert_after Rack::Runtime, Rack::RequestIDPassthrough
   end
 end
 ```
 
 ## Configuration Example
-```ruby
-# somewhere in your app maybe an initializer?
-RackRequestIDPassthrough.source_headers: %w(HTTP_FUNKY_TOWN HTTP_LESS_IMPORTANT) # List of source headers to look for request ids in
-RackRequestIDPassthrough.response_headers: %w(OUTGOING) # Controls the response headers sent back to the browser
-RackRequestIDPassthrough.http_headers: %w(OUTGOING_CALL) # Name of http headers that will be appended to all outgoing http calls
 
+Create an initializer file:
+```ruby
+# ./config/initializers/rack-request-id-passthrough.rb
+
+RackRequestIDPassthrough.source_headers = %w(HTTP_FUNKY_TOWN HTTP_LESS_IMPORTANT) # List of source headers to look for request ids in
+RackRequestIDPassthrough.response_headers = %w(OUTGOING) # Controls the response headers sent back to the browser
+RackRequestIDPassthrough.http_headers = %w(OUTGOING_CALL) # Name of http headers that will be appended to all outgoing http calls
+```
+
+```ruby
 # ./config/application.rb
+
 config.middleware.insert_after Rack::RequestIDPassthrough
 ```
 There are three main configuration options
@@ -49,7 +66,7 @@ There are three main configuration options
 - outgoing_headers: An array of headers which will be appended to all outgoing http/https requests
 - http_headers: An array of http headers that will be appended to all outgoing http calls, if you don't want to append then set this to []
 
-So in the example above ridp would check the HTTP headers FUNKY_TOWN and LESS_IMPORTANT for a value (in that order).  If it found one it would add it ```Thread.current[:request_id_passthrough]``` for usage.  It would also add an HTTP header called OUTGOING to all http requests going thru net/http that contains the request id. 
+So in the example above ridp would check the HTTP headers FUNKY_TOWN and LESS_IMPORTANT for a value (in that order).  If it found one it would add it ```Thread.current[:request_id_passthrough]``` for usage.  It would also add an HTTP header called OUTGOING to all http requests going thru net/http that contains the request id.
 
 ## Contributing
 

--- a/lib/rack-request-id-passthrough/version.rb
+++ b/lib/rack-request-id-passthrough/version.rb
@@ -1,0 +1,3 @@
+module RackRequestIDPassthrough
+  VERSION = '1.2.2'
+end

--- a/lib/rack/request-id-passthrough.rb
+++ b/lib/rack/request-id-passthrough.rb
@@ -22,9 +22,11 @@ module Rack
     end
 
     def call(env)
-      status, headers, response = @app.call(env)
       Thread.current[:request_id_passthrough] = determine_request_id(env)
       Thread.current[:add_request_id_to_http] = @patch_http
+
+      status, headers, response = @app.call(env)
+
       populate_headers(headers)
       [status, headers, response]
     end

--- a/rack-request-id-passthrough.gemspec
+++ b/rack-request-id-passthrough.gemspec
@@ -1,9 +1,10 @@
-
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'rack-request-id-passthrough/version'
 
 Gem::Specification.new do |s|
   s.name          = 'rack-request-id-passthrough'
-  s.version       = '1.2.1'
+  s.version       = RackRequestIDPassthrough::VERSION
   s.summary       = 'Middleware for persisting request IDs'
   s.description   = 'Rack middleware which will take incoming headers (such as request id) and ensure that they are passed along to outgoing http requests'
   s.author        = 'Jeffery Yeary'

--- a/spec/request-id-passthrough_spec.rb
+++ b/spec/request-id-passthrough_spec.rb
@@ -90,5 +90,4 @@ describe Net::HTTPHeader do
       expect(stub).to have_been_requested
     end
   end
-
 end


### PR DESCRIPTION
I updated Readme and added a separated file with information about the current version.

Also, I updated your RequestIDPassthrough#call method. Please take a look. As I see in your previous version you run the application before you set information from headers to the Thread. I think that you need to run `@app.call(env)` only when you added `request_id_passthrough` to the `Thread.current`

Please contact if you have any questions and thank you, I will use your gem in my projects.